### PR TITLE
Introduces new "env_var" and "file" fields to Secret to allow specifying name/mountPath on injection #minor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 .PHONY: install-piptools
 install-piptools:
 	# pip 22.1 broke pip-tools: https://github.com/jazzband/pip-tools/issues/1617
-	python -m pip install -U pip-tools setuptools wheel "pip>=22.0.3,!=22.1"
+	python3 -m pip install -U pip-tools setuptools wheel "pip>=22.0.3,!=22.1"
 
 .PHONY: update_boilerplate
 update_boilerplate:
@@ -58,7 +58,7 @@ unit_test:
 	# Skip tensorflow tests and run them with the necessary env var set so that a working (albeit slower)
 	# library is used to serialize/deserialize protobufs is used.
 	pytest -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS} && \
-		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python pytest tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
+		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python3 pytest tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
 
 doc-requirements.txt: export CUSTOM_COMPILE_COMMAND := make doc-requirements.txt
 doc-requirements.txt: doc-requirements.in install-piptools

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,9 @@ unit_test_codecov:
 unit_test:
 	# Skip tensorflow tests and run them with the necessary env var set so that a working (albeit slower)
 	# library is used to serialize/deserialize protobufs is used.
+	# Can use pytest --lf to only rerun previously failed tests.
 	pytest -m "not sandbox_test" tests/flytekit/unit/ --ignore=tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS} && \
-		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python3 pytest tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
+		PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python pytest tests/flytekit/unit/extras/tensorflow ${CODECOV_OPTS}
 
 doc-requirements.txt: export CUSTOM_COMPILE_COMMAND := make doc-requirements.txt
 doc-requirements.txt: doc-requirements.in install-piptools

--- a/flytekit/core/context_manager.py
+++ b/flytekit/core/context_manager.py
@@ -361,17 +361,18 @@ class SecretsManager(object):
         """
         self.check_env_name_key(env_name)
         env_var = self.get_secrets_env_var(group, key, group_version, env_name)
+        fpath = None
         if env_name is None:
             fpath = self.get_secrets_file(group, key, group_version)
         v = os.environ.get(env_var)
         if v is not None:
             return v
-        if os.path.exists(fpath):
+        if fpath is not None and os.path.exists(fpath):
             with open(fpath, "r") as f:
                 return f.read().strip()
         raise ValueError(
-            f"Unable to find secret for key {key} in group {group} or name {env_name}"
-            f"in Env Var:{env_var} and FilePath: {fpath}"
+            f"Unable to find secret for key {key} in group {group} or name {env_name} "
+            f"in Env Var: {env_var} or FilePath: {fpath}"
         )
 
     def get_secrets_env_var(

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -16,6 +16,7 @@ class Secret(_common.FlyteIdlEntity):
         group is the Name of the secret. For example in kubernetes secrets is the name of the secret
         key is optional and can be an individual secret identifier within the secret For k8s this is required
         version is the version of the secret. This is an optional field
+        env_name is name of the environment variable if this Secret is injected as an environment variable. This is an optional field
         mount_requirement provides a hint to the system as to how the secret should be injected
     """
 
@@ -38,6 +39,7 @@ class Secret(_common.FlyteIdlEntity):
     group: str
     key: Optional[str] = None
     group_version: Optional[str] = None
+    env_name: Optional[str] = None
     mount_requirement: MountType = MountType.ANY
 
     def __post_init__(self):
@@ -49,6 +51,7 @@ class Secret(_common.FlyteIdlEntity):
             group=self.group,
             group_version=self.group_version,
             key=self.key,
+            env_name=self.env_name,
             mount_requirement=self.mount_requirement.value,
         )
 
@@ -58,6 +61,7 @@ class Secret(_common.FlyteIdlEntity):
             group=pb2_object.group,
             group_version=pb2_object.group_version if pb2_object.group_version else None,
             key=pb2_object.key if pb2_object.key else None,
+            env_name=pb2_object.env_name if pb2_object.env_name else None,
             mount_requirement=Secret.MountType(pb2_object.mount_requirement),
         )
 

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -16,8 +16,8 @@ class Secret(_common.FlyteIdlEntity):
         group is the Name of the secret. For example in kubernetes secrets is the name of the secret
         key is optional and can be an individual secret identifier within the secret For k8s this is required
         version is the version of the secret. This is an optional field
-        env_name is name of the environment variable if this Secret is injected as an environment variable. This is an optional field
         mount_requirement provides a hint to the system as to how the secret should be injected
+        env_name is name of the environment variable if this Secret is injected as an environment variable. This is an optional field
     """
 
     class MountType(Enum):
@@ -39,8 +39,8 @@ class Secret(_common.FlyteIdlEntity):
     group: str
     key: Optional[str] = None
     group_version: Optional[str] = None
-    env_name: Optional[str] = None
     mount_requirement: MountType = MountType.ANY
+    env_name: Optional[str] = None
 
     def __post_init__(self):
         if self.group is None:
@@ -51,8 +51,8 @@ class Secret(_common.FlyteIdlEntity):
             group=self.group,
             group_version=self.group_version,
             key=self.key,
-            env_name=self.env_name,
             mount_requirement=self.mount_requirement.value,
+            env_name=self.env_name,
         )
 
     @classmethod
@@ -61,8 +61,8 @@ class Secret(_common.FlyteIdlEntity):
             group=pb2_object.group,
             group_version=pb2_object.group_version if pb2_object.group_version else None,
             key=pb2_object.key if pb2_object.key else None,
-            env_name=pb2_object.env_name if pb2_object.env_name else None,
             mount_requirement=Secret.MountType(pb2_object.mount_requirement),
+            env_name=pb2_object.env_name if pb2_object.env_name else None,
         )
 
 

--- a/flytekit/models/security.py
+++ b/flytekit/models/security.py
@@ -67,12 +67,11 @@ class Secret(_common.FlyteIdlEntity):
             )
 
     group: str
-    env_var: Optional[MountEnvVar] = None
-    file: Optional[MountFile] = None
-
     key: Optional[str] = None
     group_version: Optional[str] = None
     mount_requirement: MountType = MountType.ANY
+    env_var: Optional[MountEnvVar] = field(default_factory=lambda: None)
+    file: Optional[MountFile] = field(default_factory=lambda: None)
 
     def __post_init__(self):
         if self.group is None:
@@ -84,8 +83,8 @@ class Secret(_common.FlyteIdlEntity):
             group_version=self.group_version,
             key=self.key,
             mount_requirement=self.mount_requirement.value,
-            env_var=self.env_var.to_flyte_idl() if self.env_var else None,
-            file=self.file.to_flyte_idl() if self.file else None,
+            env_var=_sec.Secret.MountEnvVar(name=self.env_var.name) if self.env_var else None,
+            file=_sec.Secret.MountFile(path=self.file.path) if self.file else None,
         )
 
     @classmethod

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -55,6 +55,7 @@ class SQLAlchemyConfig(object):
             "group": secret.group,
             "key": secret.key,
             "group_version": secret.group_version,
+            "env_name": secret.name,
             "mount_requirement": secret.mount_requirement.value,
         }
 

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -56,7 +56,7 @@ class SQLAlchemyConfig(object):
             "key": secret.key,
             "group_version": secret.group_version,
             "mount_requirement": secret.mount_requirement.value,
-            "env_name": secret.env_name,
+            "mount_target": secret.mount_target,
         }
 
     def secret_connect_args_to_dicts(self) -> typing.Optional[typing.Dict[str, typing.Dict[str, typing.Optional[str]]]]:

--- a/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
+++ b/plugins/flytekit-sqlalchemy/flytekitplugins/sqlalchemy/task.py
@@ -55,8 +55,8 @@ class SQLAlchemyConfig(object):
             "group": secret.group,
             "key": secret.key,
             "group_version": secret.group_version,
-            "env_name": secret.name,
             "mount_requirement": secret.mount_requirement.value,
+            "env_name": secret.env_name,
         }
 
     def secret_connect_args_to_dicts(self) -> typing.Optional[typing.Dict[str, typing.Dict[str, typing.Optional[str]]]]:

--- a/tests/flytekit/common/parameterizers.py
+++ b/tests/flytekit/common/parameterizers.py
@@ -238,6 +238,7 @@ LIST_OF_SECRETS = [
     None,
     security.Secret(group="x", key="g"),
     security.Secret(group="x", key="y", mount_requirement=security.Secret.MountType.ANY),
+    security.Secret(group="x", key="y", env_name="z", mount_requirement=security.Secret.MountType.ANY),
     security.Secret(group="x", key="y", group_version="1", mount_requirement=security.Secret.MountType.FILE),
 ]
 

--- a/tests/flytekit/common/parameterizers.py
+++ b/tests/flytekit/common/parameterizers.py
@@ -238,7 +238,7 @@ LIST_OF_SECRETS = [
     None,
     security.Secret(group="x", key="g"),
     security.Secret(group="x", key="y", mount_requirement=security.Secret.MountType.ANY),
-    security.Secret(group="x", key="y", env_name="z", mount_requirement=security.Secret.MountType.ANY),
+    security.Secret(group="x", key="y", mount_target=security.Secret.MountEnvVar(name="z"), mount_requirement=security.Secret.MountType.ANY),
     security.Secret(group="x", key="y", group_version="1", mount_requirement=security.Secret.MountType.FILE),
 ]
 

--- a/tests/flytekit/common/parameterizers.py
+++ b/tests/flytekit/common/parameterizers.py
@@ -238,7 +238,9 @@ LIST_OF_SECRETS = [
     None,
     security.Secret(group="x", key="g"),
     security.Secret(group="x", key="y", mount_requirement=security.Secret.MountType.ANY),
-    security.Secret(group="x", key="y", mount_target=security.Secret.MountEnvVar(name="z"), mount_requirement=security.Secret.MountType.ANY),
+    security.Secret(group="x", key="y", env_var=security.Secret.MountEnvVar(name="z")),
+    security.Secret(group="x", key="y", file=security.Secret.MountFile(path="/z")),
+    security.Secret(group="x", key="y", group_version="1", mount_requirement=security.Secret.MountType.ENV_VAR),
     security.Secret(group="x", key="y", group_version="1", mount_requirement=security.Secret.MountType.FILE),
 ]
 


### PR DESCRIPTION
# TL;DR
Introduces new fields to the `Secret` object:
- `env_var`
- `file`

Allowing users to directly specify a name or mountPath for the Secret, without having to specify a full PodTemplate(name). The old `mount_requirement` can still be used. Example:

```python

from flytekit import task, workflow, Secret
import flytekit
import os


@task(
    secret_requests=[
        Secret(
            group="user-info",
            key="user_secret",
            mount_requirement=Secret.MountType.FILE,
        ),
        Secret(
            group="user-info",
            key="user_secret",
            mount_requirement=Secret.MountType.ENV_VAR,
        ),
    ]
)
def old() -> None:
    context = flytekit.current_context()
    print("old")

    # mount_requirement=ENV_VAR
    print(context.secrets.get(env_name="_FSEC_USER-INFO_USER_SECRET"))

    # mount_requirement=FILE
    with open('/etc/flyte/secrets/user-info/user_secret', 'r') as infile:
        print(infile.readlines())
    return True

@task(
    secret_requests=[
        Secret(
            group="user-info",
            key="user_secret",
            env_var=Secret.MountEnvVar(name="foo"),
        ),
        Secret(
            group="user-info",
            key="user_secret",
            file=Secret.MountFile(path="/foo"),
        ),
    ]
)

def new() -> None:
    context = flytekit.current_context()
    print("new")

    # env_var=
    print(context.secrets.get(env_name="foo"))

    # file=
    with open('/foo/user_secret', 'r') as infile:
        print(infile.readlines())


@workflow
def training_workflow(hyperparameters: dict) -> None:
    """Put all of the steps together into a single workflow."""
    old()
    new()

```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
